### PR TITLE
Upgrade to latest bunsen-core

### DIFF
--- a/blueprints/ember-bunsen-core/index.js
+++ b/blueprints/ember-bunsen-core/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   afterInstall: function () {
     return this.addPackagesToProject([
-      {name: 'bunsen-core', target: '>=0.9.0 <= 2.0.0'}
+      {name: 'bunsen-core', target: '>=0.9.1 <= 2.0.0'}
     ])
       .then(() => {
         return this.addAddonsToProject({

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
-    "bunsen-core": ">=0.9.0 <= 2.0.0",
+    "bunsen-core": ">=0.9.1 <= 2.0.0",
     "ember-cli": "2.7.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",

--- a/tests/unit/validator/cell-test.js
+++ b/tests/unit/validator/cell-test.js
@@ -139,7 +139,7 @@ describe('Unit: validator/cell', () => {
             },
             {
               path: '#/cellDefinitions/main/children/2',
-              message: '"children", "extends" or "model" must be defined for each cell.'
+              message: '"children", "extends", or "model" must be defined for each cell.'
             },
             {
               path: '#/cellDefinitions/main/children/3/model',

--- a/tests/unit/validator/cell-test.js
+++ b/tests/unit/validator/cell-test.js
@@ -139,7 +139,7 @@ describe('Unit: validator/cell', () => {
             },
             {
               path: '#/cellDefinitions/main/children/2',
-              message: 'Either "model" or "extends" must be defined for each cell.'
+              message: '"children", "extends" or "model" must be defined for each cell.'
             },
             {
               path: '#/cellDefinitions/main/children/3/model',


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Upgraded** to latest `bunsen-core` which fixes a bug with cells that define `children` but not `model` or `extends`.

