### PR TITLE
Fixes bug in bunsen's evaluate-conditions

### DIFF
--- a/blueprints/ember-bunsen-core/index.js
+++ b/blueprints/ember-bunsen-core/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   afterInstall: function () {
     return this.addPackagesToProject([
-      {name: 'bunsen-core', target: '0.13.0'}
+      {name: 'bunsen-core', target: '0.13.1'}
     ])
       .then(() => {
         return this.addAddonsToProject({


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* Fixes `properties: undefined` bug in `evaluate`
