### PR TITLE
Upgrade to latest bunsen-core

### DIFF
--- a/blueprints/ember-bunsen-core/index.js
+++ b/blueprints/ember-bunsen-core/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   afterInstall: function () {
     return this.addPackagesToProject([
-      {name: 'bunsen-core', target: '0.14.1'}
+      {name: 'bunsen-core', target: '0.16.0'}
     ])
       .then(() => {
         return this.addAddonsToProject({

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.6",
-    "bunsen-core": "0.14.1",
+    "bunsen-core": "0.16.0",
     "ember-cli": "2.8.0",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-dependency-checker": "^1.2.0",

--- a/tests/unit/validator/custom-formats/ipv6-address-test.js
+++ b/tests/unit/validator/custom-formats/ipv6-address-test.js
@@ -2,40 +2,40 @@ import {expect} from 'chai'
 import {describe, it} from 'mocha'
 import ipv6Address from 'bunsen-core/validator/custom-formats/ipv6-address'
 
-describe('validator/custom-formats/ipv6-address', () => {
-  it('returns false when value is undefined', () => {
+describe('validator/custom-formats/ipv6-address', function () {
+  it('returns false when value is undefined', function () {
     expect(ipv6Address(undefined)).to.be.false
   })
 
-  it('returns false when value is null', () => {
+  it('returns false when value is null', function () {
     expect(ipv6Address(null)).to.be.false
   })
 
-  it('returns false when value is an object', () => {
+  it('returns false when value is an object', function () {
     expect(ipv6Address({})).to.be.false
   })
 
-  it('returns false when value is an array', () => {
+  it('returns false when value is an array', function () {
     expect(ipv6Address([])).to.be.false
   })
 
-  it('returns false when value is an integer', () => {
+  it('returns false when value is an integer', function () {
     expect(ipv6Address(1)).to.be.false
   })
 
-  it('returns false when value is a float', () => {
+  it('returns false when value is a float', function () {
     expect(ipv6Address(0.5)).to.be.false
   })
 
-  it('returns false when value is NaN', () => {
+  it('returns false when value is NaN', function () {
     expect(ipv6Address(NaN)).to.be.false
   })
 
-  it('returns false when value is Infinity', () => {
+  it('returns false when value is Infinity', function () {
     expect(ipv6Address(Infinity)).to.be.false
   })
 
-  it('returns false when value does not consist of eight groups', () => {
+  it('returns false when value does not consist of eight groups', function () {
     expect(ipv6Address('0000')).to.be.false
     expect(ipv6Address('0000:0000')).to.be.false
     expect(ipv6Address('0000:0000:0000')).to.be.false
@@ -45,7 +45,7 @@ describe('validator/custom-formats/ipv6-address', () => {
     expect(ipv6Address('0000:0000:0000:0000:0000:0000:0000')).to.be.false
   })
 
-  it('returns false when groups contain non-hex characters', () => {
+  it('returns false when groups contain non-hex characters', function () {
     expect(ipv6Address('000g:0000:0000:0000:0000:0000:0000:0000')).to.be.false
     expect(ipv6Address('0000:000g:0000:0000:0000:0000:0000:0000')).to.be.false
     expect(ipv6Address('0000:0000:000g:0000:0000:0000:0000:0000')).to.be.false
@@ -56,7 +56,7 @@ describe('validator/custom-formats/ipv6-address', () => {
     expect(ipv6Address('0000:0000:0000:0000:0000:0000:0000:000g')).to.be.false
   })
 
-  it('returns false when groups contain negative numbers', () => {
+  it('returns false when groups contain negative numbers', function () {
     expect(ipv6Address('-0001:0000:0000:0000:0000:0000:0000:0000')).to.be.false
     expect(ipv6Address('0000:-0001:0000:0000:0000:0000:0000:0000')).to.be.false
     expect(ipv6Address('0000:0000:-0001:0000:0000:0000:0000:0000')).to.be.false
@@ -67,7 +67,7 @@ describe('validator/custom-formats/ipv6-address', () => {
     expect(ipv6Address('0000:0000:0000:0000:0000:0000:0000:-0001')).to.be.false
   })
 
-  it('returns true when valid IPv6 address', () => {
+  it('returns true when valid IPv6 address', function () {
     expect(ipv6Address('0000:0000:0000:0000:0000:0000:0000:0000')).to.be.true
     expect(ipv6Address('2001:0db8:0000:0042:0000:8a2e:0370:7334')).to.be.true
   })

--- a/tests/unit/validator/custom-formats/mac-address-test.js
+++ b/tests/unit/validator/custom-formats/mac-address-test.js
@@ -1,0 +1,68 @@
+import {expect} from 'chai'
+import {describe, it} from 'mocha'
+import macAddress from 'bunsen-core/validator/custom-formats/mac-address'
+
+describe('validator/custom-formats/mac-address', function () {
+  it('returns false when value is undefined', function () {
+    expect(macAddress(undefined)).to.be.equal(false)
+  })
+
+  it('returns false when value is null', function () {
+    expect(macAddress(null)).to.be.equal(false)
+  })
+
+  it('returns false when value is an object', function () {
+    expect(macAddress({})).to.be.equal(false)
+  })
+
+  it('returns false when value is an array', function () {
+    expect(macAddress([])).to.be.equal(false)
+  })
+
+  it('returns false when value is an integer', function () {
+    expect(macAddress(1)).to.be.equal(false)
+  })
+
+  it('returns false when value is a float', function () {
+    expect(macAddress(0.5)).to.be.equal(false)
+  })
+
+  it('returns false when value is NaN', function () {
+    expect(macAddress(NaN)).to.be.equal(false)
+  })
+
+  it('returns false when value is Infinity', function () {
+    expect(macAddress(Infinity)).to.be.equal(false)
+  })
+
+  it('returns false when value does not consist of six groups', function () {
+    expect(macAddress('00')).to.be.equal(false)
+    expect(macAddress('00:00')).to.be.equal(false)
+    expect(macAddress('00:00:00')).to.be.equal(false)
+    expect(macAddress('00:00:00:00')).to.be.equal(false)
+    expect(macAddress('00:00:00:00:00')).to.be.equal(false)
+  })
+
+  it('returns false when groups contain non-hex characters', function () {
+    expect(macAddress('0g:00:00:00:00:00')).to.be.equal(false)
+    expect(macAddress('00:0g:00:00:00:00')).to.be.equal(false)
+    expect(macAddress('00:00:0g:00:00:00')).to.be.equal(false)
+    expect(macAddress('00:00:00:0g:00:00')).to.be.equal(false)
+    expect(macAddress('00:00:00:00:0g:00')).to.be.equal(false)
+    expect(macAddress('00:00:00:00:00:0g')).to.be.equal(false)
+  })
+
+  it('returns false when groups contain negative numbers', function () {
+    expect(macAddress('-01:00:00:00:00:00')).to.be.equal(false)
+    expect(macAddress('00:-01:00:00:00:00')).to.be.equal(false)
+    expect(macAddress('00:00:-01:00:00:00')).to.be.equal(false)
+    expect(macAddress('00:00:00:-01:00:00')).to.be.equal(false)
+    expect(macAddress('00:00:00:00:-01:00')).to.be.equal(false)
+    expect(macAddress('00:00:00:00:00:-01')).to.be.equal(false)
+  })
+
+  it('returns true when valid MAC address', function () {
+    expect(macAddress('00:00:00:00:00:00')).to.be.equal(true)
+    expect(macAddress('01:b8:00:42:00:2e')).to.be.equal(true)
+  })
+})

--- a/tests/unit/validator/custom-formats/mac-interface-test.js
+++ b/tests/unit/validator/custom-formats/mac-interface-test.js
@@ -1,0 +1,81 @@
+import {expect} from 'chai'
+import {describe, it} from 'mocha'
+import macInterface from 'bunsen-core/validator/custom-formats/mac-interface'
+
+describe('validator/custom-formats/mac-prefix', function () {
+  it('returns false when value is undefined', function () {
+    expect(macInterface(undefined)).to.be.equal(false)
+  })
+
+  it('returns false when value is null', function () {
+    expect(macInterface(null)).to.be.equal(false)
+  })
+
+  it('returns false when value is an object', function () {
+    expect(macInterface({})).to.be.equal(false)
+  })
+
+  it('returns false when value is an array', function () {
+    expect(macInterface([])).to.be.equal(false)
+  })
+
+  it('returns false when value is an integer', function () {
+    expect(macInterface(1)).to.be.equal(false)
+  })
+
+  it('returns false when value is a float', function () {
+    expect(macInterface(0.5)).to.be.equal(false)
+  })
+
+  it('returns false when value is NaN', function () {
+    expect(macInterface(NaN)).to.be.equal(false)
+  })
+
+  it('returns false when value is Infinity', function () {
+    expect(macInterface(Infinity)).to.be.equal(false)
+  })
+
+  it('returns false when MAC mask is missing', function () {
+    expect(macInterface('00:00:00:00:00:00')).to.be.equal(false)
+  })
+
+  it('returns false when mac address does not consist of six groups', function () {
+    expect(macInterface('00:00:00:00:00/0')).to.be.equal(false)
+  })
+
+  it('returns false when groups contain non-hex characters', function () {
+    expect(macInterface('0g:00:00:00:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:0g:00:00:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:0g:00:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:00:0g:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:00:00:0g:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:00:00:00:0g/0')).to.be.equal(false)
+  })
+
+  it('returns false when groups contain negative numbers', function () {
+    expect(macInterface('-00:00:00:00:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:-00:00:00:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:-00:00:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:00:-00:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:00:00:-00:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:00:00:00:-00/0')).to.be.equal(false)
+  })
+
+  it('returns false when groups contain numbers > ff', function () {
+    expect(macInterface('1ff:00:00:00:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:1ff:00:00:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:1ff:00:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:00:1ff:00:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:00:00:1ff:00/0')).to.be.equal(false)
+    expect(macInterface('00:00:00:00:00:1ff/0')).to.be.equal(false)
+  })
+
+  it('returns false when invalid MAC prefix', function () {
+    expect(macInterface('ff:ff:00:00:00:00/16')).to.be.equal(false)
+  })
+
+  it('returns true when valid MAC prefix', function () {
+    expect(macInterface('ff:ff:ff:00:00:00/16')).to.be.equal(true)
+    expect(macInterface('ff:ff:ff:00:00:01/24')).to.be.equal(true)
+  })
+})

--- a/tests/unit/validator/custom-formats/mac-prefix-test.js
+++ b/tests/unit/validator/custom-formats/mac-prefix-test.js
@@ -1,0 +1,81 @@
+import {expect} from 'chai'
+import {describe, it} from 'mocha'
+import macPrefix from 'bunsen-core/validator/custom-formats/mac-prefix'
+
+describe('validator/custom-formats/mac-prefix', function () {
+  it('returns false when value is undefined', function () {
+    expect(macPrefix(undefined)).to.be.equal(false)
+  })
+
+  it('returns false when value is null', function () {
+    expect(macPrefix(null)).to.be.equal(false)
+  })
+
+  it('returns false when value is an object', function () {
+    expect(macPrefix({})).to.be.equal(false)
+  })
+
+  it('returns false when value is an array', function () {
+    expect(macPrefix([])).to.be.equal(false)
+  })
+
+  it('returns false when value is an integer', function () {
+    expect(macPrefix(1)).to.be.equal(false)
+  })
+
+  it('returns false when value is a float', function () {
+    expect(macPrefix(0.5)).to.be.equal(false)
+  })
+
+  it('returns false when value is NaN', function () {
+    expect(macPrefix(NaN)).to.be.equal(false)
+  })
+
+  it('returns false when value is Infinity', function () {
+    expect(macPrefix(Infinity)).to.be.equal(false)
+  })
+
+  it('returns false when MAC mask is missing', function () {
+    expect(macPrefix('00:00:00:00:00:00')).to.be.equal(false)
+  })
+
+  it('returns false when mac address does not consist of six groups', function () {
+    expect(macPrefix('00:00:00:00:00/0')).to.be.equal(false)
+  })
+
+  it('returns false when groups contain non-hex characters', function () {
+    expect(macPrefix('0g:00:00:00:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:0g:00:00:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:0g:00:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:00:0g:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:00:00:0g:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:00:00:00:0g/0')).to.be.equal(false)
+  })
+
+  it('returns false when groups contain negative numbers', function () {
+    expect(macPrefix('-00:00:00:00:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:-00:00:00:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:-00:00:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:00:-00:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:00:00:-00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:00:00:00:-00/0')).to.be.equal(false)
+  })
+
+  it('returns false when groups contain numbers > ff', function () {
+    expect(macPrefix('1ff:00:00:00:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:1ff:00:00:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:1ff:00:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:00:1ff:00:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:00:00:1ff:00/0')).to.be.equal(false)
+    expect(macPrefix('00:00:00:00:00:1ff/0')).to.be.equal(false)
+  })
+
+  it('returns false when invalid MAC prefix', function () {
+    expect(macPrefix('ff:ff:ff:00:00:00/16')).to.be.equal(false)
+  })
+
+  it('returns true when valid MAC prefix', function () {
+    expect(macPrefix('ff:ff:00:00:00:00/16')).to.be.equal(true)
+    expect(macPrefix('ff:ff:ff:00:00:00/24')).to.be.equal(true)
+  })
+})

--- a/tests/unit/validator/index-test.js
+++ b/tests/unit/validator/index-test.js
@@ -148,7 +148,7 @@ describe('Unit: validator', function () {
       }
     ]
       .forEach((view) => {
-        describe('when valid', () => {
+        describe('when valid', function () {
           var result
 
           beforeEach(() => {
@@ -170,7 +170,7 @@ describe('Unit: validator', function () {
             result = validate(view, model, renderers, validateRenderer)
           })
 
-          it('returns proper result', () => {
+          it('returns proper result', function () {
             expect(result).deep.equal({
               errors: [],
               warnings: []
@@ -179,7 +179,7 @@ describe('Unit: validator', function () {
         })
       })
 
-    describe('when valid', () => {
+    describe('when valid', function () {
       var result
 
       beforeEach(() => {
@@ -238,7 +238,7 @@ describe('Unit: validator', function () {
         result = validate(view, model, renderers, validateRenderer)
       })
 
-      it('returns proper result', () => {
+      it('returns proper result', function () {
         expect(result).deep.equal({
           errors: [],
           warnings: []
@@ -318,6 +318,120 @@ describe('Unit: validator', function () {
           path: '#/cells/0',
           message: 'Invalid value "baz" for "extends" Valid options are ["bar","foo"]'
         }])
+      })
+    })
+
+    describe('when modelType is invalid on root cell', function () {
+      var result
+
+      beforeEach(function () {
+        const model = {
+          properties: {
+            foo: {
+              type: 'string'
+            }
+          },
+          type: 'object'
+        }
+
+        const view = {
+          cells: [
+            {
+              model: 'foo',
+              renderer: {
+                name: 'select',
+                options: {
+                  modelType: 'bar'
+                }
+              }
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        }
+
+        const renderers = []
+
+        function validateRenderer (rendererName) {
+          return true
+        }
+
+        function validateModelType () {
+          return false
+        }
+
+        result = validate(view, model, renderers, validateRenderer, validateModelType)
+      })
+
+      it('returns proper result', function () {
+        expect(result).deep.equal({
+          errors: [
+            {
+              message: 'Invalid modelType reference "bar"',
+              path: '#/cells/0/renderer/options'
+            }
+          ],
+          warnings: []
+        })
+      })
+    })
+
+    describe('when modelType is invalid on root cell child', function () {
+      var result
+
+      beforeEach(function () {
+        const model = {
+          properties: {
+            foo: {
+              type: 'string'
+            }
+          },
+          type: 'object'
+        }
+
+        const view = {
+          cells: [
+            {
+              children: [
+                {
+                  model: 'foo',
+                  renderer: {
+                    name: 'select',
+                    options: {
+                      modelType: 'bar'
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          type: 'form',
+          version: '2.0'
+        }
+
+        const renderers = []
+
+        function validateRenderer (rendererName) {
+          return true
+        }
+
+        function validateModelType () {
+          return false
+        }
+
+        result = validate(view, model, renderers, validateRenderer, validateModelType)
+      })
+
+      it('returns proper result', function () {
+        expect(result).deep.equal({
+          errors: [
+            {
+              message: 'Invalid modelType reference "bar"',
+              path: '#/cells/0/children/0/renderer/options'
+            }
+          ],
+          warnings: []
+        })
       })
     })
   })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Upgraded** to latest `bunsen-core` to get new MAC address custom formats and `modelType` validation for select renderers.

