### PR TITLE
Fixed populateQuery() to not throw error

### DIFF
--- a/blueprints/ember-bunsen-core/index.js
+++ b/blueprints/ember-bunsen-core/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   afterInstall: function () {
     return this.addPackagesToProject([
-      {name: 'bunsen-core', target: '0.16.1'}
+      {name: 'bunsen-core', target: '0.16.2'}
     ])
       .then(() => {
         return this.addAddonsToProject({

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.6",
-    "bunsen-core": "0.16.1",
+    "bunsen-core": "0.16.2",
     "ember-cli": "2.8.0",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-dependency-checker": "^1.2.0",

--- a/tests/unit/utils-test.js
+++ b/tests/unit/utils-test.js
@@ -112,5 +112,11 @@ describe('utils', function () {
         utils.populateQuery({}, undefined)
       }).not.to.throw()
     })
+
+    it('does not throw error when query dependency is not present', function () {
+      expect(function () {
+        utils.populateQuery({}, {node: '${./node}'})
+      }).not.to.throw()
+    })
   })
 })


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** `populateQuery()` to not throw error.

