### PR TITLE
Allow more value types in select and support /multicast as a mask

### DIFF
--- a/blueprints/ember-bunsen-core/index.js
+++ b/blueprints/ember-bunsen-core/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   afterInstall: function () {
     return this.addPackagesToProject([
-      {name: 'bunsen-core', target: '0.16.3'}
+      {name: 'bunsen-core', target: '0.16.4'}
     ])
       .then(() => {
         return this.addAddonsToProject({

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.6",
-    "bunsen-core": "0.16.3",
+    "bunsen-core": "0.16.4",
     "ember-cli": "2.8.0",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-dependency-checker": "^1.2.0",

--- a/tests/unit/validator/custom-formats/mac-interface-test.js
+++ b/tests/unit/validator/custom-formats/mac-interface-test.js
@@ -70,12 +70,12 @@ describe('validator/custom-formats/mac-prefix', function () {
     expect(macInterface('00:00:00:00:00:1ff/0')).to.be.equal(false)
   })
 
-  it('returns false when invalid MAC prefix', () => {
+  it('returns false when invalid MAC prefix', function () {
     expect(macInterface('ff:ff:00:00:00:00/16')).to.be.equal(false)
     expect(macInterface('f0:ff:00:00:00:00/multicast')).to.be.equal(false)
   })
 
-  it('returns true when valid MAC prefix', () => {
+  it('returns true when valid MAC prefix', function () {
     expect(macInterface('ff:ff:ff:00:00:00/16')).to.be.equal(true)
     expect(macInterface('ff:ff:ff:00:00:01/24')).to.be.equal(true)
     expect(macInterface('ff:ff:ff:00:00:01/multicast')).to.be.equal(true)

--- a/tests/unit/validator/custom-formats/mac-interface-test.js
+++ b/tests/unit/validator/custom-formats/mac-interface-test.js
@@ -70,12 +70,14 @@ describe('validator/custom-formats/mac-prefix', function () {
     expect(macInterface('00:00:00:00:00:1ff/0')).to.be.equal(false)
   })
 
-  it('returns false when invalid MAC prefix', function () {
+  it('returns false when invalid MAC prefix', () => {
     expect(macInterface('ff:ff:00:00:00:00/16')).to.be.equal(false)
+    expect(macInterface('f0:ff:00:00:00:00/multicast')).to.be.equal(false)
   })
 
-  it('returns true when valid MAC prefix', function () {
+  it('returns true when valid MAC prefix', () => {
     expect(macInterface('ff:ff:ff:00:00:00/16')).to.be.equal(true)
     expect(macInterface('ff:ff:ff:00:00:01/24')).to.be.equal(true)
+    expect(macInterface('ff:ff:ff:00:00:01/multicast')).to.be.equal(true)
   })
 })

--- a/tests/unit/validator/custom-formats/mac-interface-test.js
+++ b/tests/unit/validator/custom-formats/mac-interface-test.js
@@ -70,12 +70,12 @@ describe('validator/custom-formats/mac-prefix', function () {
     expect(macInterface('00:00:00:00:00:1ff/0')).to.be.equal(false)
   })
 
-  it('returns false when invalid MAC prefix', function () {
+  it('returns false when invalid MAC interface', function () {
     expect(macInterface('ff:ff:00:00:00:00/16')).to.be.equal(false)
     expect(macInterface('f0:ff:00:00:00:00/multicast')).to.be.equal(false)
   })
 
-  it('returns true when valid MAC prefix', function () {
+  it('returns true when valid MAC interface', function () {
     expect(macInterface('ff:ff:ff:00:00:00/16')).to.be.equal(true)
     expect(macInterface('ff:ff:ff:00:00:01/24')).to.be.equal(true)
     expect(macInterface('ff:ff:ff:00:00:01/multicast')).to.be.equal(true)

--- a/tests/unit/validator/custom-formats/mac-prefix-test.js
+++ b/tests/unit/validator/custom-formats/mac-prefix-test.js
@@ -70,12 +70,14 @@ describe('validator/custom-formats/mac-prefix', function () {
     expect(macPrefix('00:00:00:00:00:1ff/0')).to.be.equal(false)
   })
 
-  it('returns false when invalid MAC prefix', function () {
+  it('returns false when invalid MAC interface', () => {
     expect(macPrefix('ff:ff:ff:00:00:00/16')).to.be.equal(false)
+    expect(macPrefix('f0:ff:ff:00:00:00/multicast')).to.be.equal(false)
   })
 
-  it('returns true when valid MAC prefix', function () {
+  it('returns true when valid MAC interface', () => {
     expect(macPrefix('ff:ff:00:00:00:00/16')).to.be.equal(true)
     expect(macPrefix('ff:ff:ff:00:00:00/24')).to.be.equal(true)
+    expect(macPrefix('ff:ff:ff:00:00:00/multicast')).to.be.equal(true)
   })
 })

--- a/tests/unit/validator/custom-formats/mac-prefix-test.js
+++ b/tests/unit/validator/custom-formats/mac-prefix-test.js
@@ -70,12 +70,12 @@ describe('validator/custom-formats/mac-prefix', function () {
     expect(macPrefix('00:00:00:00:00:1ff/0')).to.be.equal(false)
   })
 
-  it('returns false when invalid MAC interface', function () {
+  it('returns false when invalid MAC prefix', function () {
     expect(macPrefix('ff:ff:ff:00:00:00/16')).to.be.equal(false)
     expect(macPrefix('f0:ff:ff:00:00:00/multicast')).to.be.equal(false)
   })
 
-  it('returns true when valid MAC interface', function () {
+  it('returns true when valid MAC prefix', function () {
     expect(macPrefix('ff:ff:00:00:00:00/16')).to.be.equal(true)
     expect(macPrefix('ff:ff:ff:00:00:00/24')).to.be.equal(true)
     expect(macPrefix('ff:ff:ff:00:00:00/multicast')).to.be.equal(true)

--- a/tests/unit/validator/custom-formats/mac-prefix-test.js
+++ b/tests/unit/validator/custom-formats/mac-prefix-test.js
@@ -70,12 +70,12 @@ describe('validator/custom-formats/mac-prefix', function () {
     expect(macPrefix('00:00:00:00:00:1ff/0')).to.be.equal(false)
   })
 
-  it('returns false when invalid MAC interface', () => {
+  it('returns false when invalid MAC interface', function () {
     expect(macPrefix('ff:ff:ff:00:00:00/16')).to.be.equal(false)
     expect(macPrefix('f0:ff:ff:00:00:00/multicast')).to.be.equal(false)
   })
 
-  it('returns true when valid MAC interface', () => {
+  it('returns true when valid MAC interface', function () {
     expect(macPrefix('ff:ff:00:00:00:00/16')).to.be.equal(true)
     expect(macPrefix('ff:ff:ff:00:00:00/24')).to.be.equal(true)
     expect(macPrefix('ff:ff:ff:00:00:00/multicast')).to.be.equal(true)

--- a/tests/unit/validator/view-schema/v2-test.js
+++ b/tests/unit/validator/view-schema/v2-test.js
@@ -1,0 +1,112 @@
+'use strict'
+
+import {expect} from 'chai'
+import {beforeEach, describe, it} from 'mocha'
+import ZSchema from 'z-schema'
+import model from 'bunsen-core/validator/view-schemas/v2'
+
+describe('v2 schema validation', () => {
+  let schemaValidator
+  beforeEach(function () {
+    schemaValidator = new ZSchema({
+      breakOnFirstError: false
+    })
+  })
+
+  describe('selectRenderer', function () {
+    let value
+    beforeEach(function () {
+      value = {
+        type: 'form',
+        version: '2.0',
+        cells: [
+          {
+            model: 'foo',
+            renderer: {
+              name: 'select',
+              options: {
+                data: [{
+                  label: 'label',
+                  value: 'value'
+                }],
+                none: {
+                  label: 'None',
+                  present: true,
+                  value: ''
+                }
+              }
+            }
+          }
+        ]
+      }
+    })
+
+    describe('when data value is specified', function () {
+      it('passes validation when value is string', function () {
+        expect(schemaValidator.validate(value, model)).to.equal(true)
+      })
+
+      it('passes validation when value is number', function () {
+        value.cells[0].renderer.options.data[0].value = 1.1
+        expect(schemaValidator.validate(value, model)).to.equal(true)
+      })
+
+      it('passes validation when value is integer', function () {
+        value.cells[0].renderer.options.data[0].value = 1
+        expect(schemaValidator.validate(value, model)).to.equal(true)
+      })
+      it('passes validation when value is boolean', function () {
+        value.cells[0].renderer.options.data[0].value = true
+        expect(schemaValidator.validate(value, model)).to.equal(true)
+      })
+      it('passes validation when value is object', function () {
+        value.cells[0].renderer.options.data[0].value = {}
+        expect(schemaValidator.validate(value, model)).to.equal(true)
+      })
+
+      it('fails validation when value is an array', function () {
+        value.cells[0].renderer.options.data[0].value = []
+        expect(schemaValidator.validate(value, model)).to.equal(false)
+      })
+
+      it('fails validation when value is null', function () {
+        value.cells[0].renderer.options.data[0].value = null
+        expect(schemaValidator.validate(value, model)).to.equal(false)
+      })
+    })
+
+    describe('when none value is specified', function () {
+      it('passes validation when value is string', function () {
+        expect(schemaValidator.validate(value, model)).to.equal(true)
+      })
+
+      it('passes validation when value is number', function () {
+        value.cells[0].renderer.options.none.value = 1.1
+        expect(schemaValidator.validate(value, model)).to.equal(true)
+      })
+
+      it('passes validation when value is integer', function () {
+        value.cells[0].renderer.options.none.value = 1
+        expect(schemaValidator.validate(value, model)).to.equal(true)
+      })
+      it('passes validation when value is boolean', function () {
+        value.cells[0].renderer.options.none.value = true
+        expect(schemaValidator.validate(value, model)).to.equal(true)
+      })
+      it('passes validation when value is object', function () {
+        value.cells[0].renderer.options.none.value = {}
+        expect(schemaValidator.validate(value, model)).to.equal(true)
+      })
+
+      it('fails validation when value is an array', function () {
+        value.cells[0].renderer.options.none.value = []
+        expect(schemaValidator.validate(value, model)).to.equal(false)
+      })
+
+      it('fails validation when value is null', function () {
+        value.cells[0].renderer.options.none.value = null
+        expect(schemaValidator.validate(value, model)).to.equal(false)
+      })
+    })
+  })
+})


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* Updating to version of `bunsen-core` that will allow more types in the select data options.
