### PR TITLE
Add IPv6 formats

### DIFF
--- a/blueprints/ember-bunsen-core/index.js
+++ b/blueprints/ember-bunsen-core/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   afterInstall: function () {
     return this.addPackagesToProject([
-      {name: 'bunsen-core', target: '0.18.3'}
+      {name: 'bunsen-core', target: '0.19.1'}
     ])
       .then(() => {
         return this.addAddonsToProject({

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.6",
-    "bunsen-core": "0.18.3",
+    "bunsen-core": "0.19.1",
     "ember-cli": "2.8.0",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-dependency-checker": "^1.2.0",

--- a/tests/unit/validator/custom-formats/ipv6-interface-test.js
+++ b/tests/unit/validator/custom-formats/ipv6-interface-test.js
@@ -1,0 +1,87 @@
+import {expect} from 'chai'
+import {describe, it} from 'mocha'
+import ipv6Interface from 'bunsen-core/validator/custom-formats/ipv6-interface'
+
+describe('validator/custom-formats/IPv6-interface', function () {
+  it('returns false when value is undefined', function () {
+    expect(ipv6Interface(undefined)).to.be.equal(false)
+  })
+
+  it('returns false when value is null', function () {
+    expect(ipv6Interface(null)).to.be.equal(false)
+  })
+
+  it('returns false when value is an object', function () {
+    expect(ipv6Interface({})).to.be.equal(false)
+  })
+
+  it('returns false when value is an array', function () {
+    expect(ipv6Interface([])).to.be.equal(false)
+  })
+
+  it('returns false when value is an integer', function () {
+    expect(ipv6Interface(1)).to.be.equal(false)
+  })
+
+  it('returns false when value is a float', function () {
+    expect(ipv6Interface(0.5)).to.be.equal(false)
+  })
+
+  it('returns false when value is NaN', function () {
+    expect(ipv6Interface(NaN)).to.be.equal(false)
+  })
+
+  it('returns false when value is Infinity', function () {
+    expect(ipv6Interface(Infinity)).to.be.equal(false)
+  })
+
+  it('returns false when network mask is missing', function () {
+    expect(ipv6Interface('0000:0000:0000:0000:0000:0000:0000:0000')).to.be.equal(false)
+  })
+
+  it('returns false when value does not consist of eight groups', function () {
+    expect(ipv6Interface('0000/0')).to.be.equal(false)
+    expect(ipv6Interface('0000:0000/0')).to.be.equal(false)
+    expect(ipv6Interface('0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Interface('0000:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Interface('0000:0000:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Interface('0000:0000:0000:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Interface('0000:0000:0000:0000:0000:0000:0000/0')).to.be.equal(false)
+  })
+
+  it('returns false when groups contain non-hex characters', function () {
+    expect(ipv6Interface('000g:0000:0000:0000:0000:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Interface('0000:000g:0000:0000:0000:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Interface('0000:0000:000g:0000:0000:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Interface('0000:0000:0000:000g:0000:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Interface('0000:0000:0000:0000:000g:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Interface('0000:0000:0000:0000:0000:000g:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Interface('0000:0000:0000:0000:0000:0000:000g:0000/0')).to.be.equal(false)
+    expect(ipv6Interface('0000:0000:0000:0000:0000:0000:0000:000g/0')).to.be.equal(false)
+  })
+
+  it('returns false when groups contain negative numbers', function () {
+    expect(ipv6Interface('-0001:0000:0000:0000:0000:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Interface('0000:-0001:0000:0000:0000:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Interface('0000:0000:-0001:0000:0000:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Interface('0000:0000:0000:-0001:0000:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Interface('0000:0000:0000:0000:-0001:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Interface('0000:0000:0000:0000:0000:-0001:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Interface('0000:0000:0000:0000:0000:0000:-0001:0000/0')).to.be.equal(false)
+    expect(ipv6Interface('0000:0000:0000:0000:0000:0000:0000:-0001/0')).to.be.equal(false)
+  })
+
+  it('returns false when invalid IPv6 interface', function () {
+    expect(ipv6Interface('12AB:0:0:CD3/60')).to.be.equal(false)
+    expect(ipv6Interface('fe80::6a05:caff:fe05:f789/128')).to.be.equal(false)
+  })
+
+  it('returns true when valid IPv6 interface', function () {
+    expect(ipv6Interface('1080:0:0:0:8:800:200C:417A/32')).to.be.equal(true)
+    expect(ipv6Interface('12AB::CD30/60')).to.be.equal(true)
+    expect(ipv6Interface('12AB::CD3/60')).to.be.equal(true)
+    expect(ipv6Interface('12AB:0:0:CD30:123:4567:89AB:CDEF/60')).to.be.equal(true)
+    expect(ipv6Interface('fe80::6a05:caff:fe05:f789/64')).to.be.equal(true)
+    expect(ipv6Interface('FEDC:BA98:7654:3210:FEDC:BA98:7654:3210/68')).to.be.equal(true)
+  })
+})

--- a/tests/unit/validator/custom-formats/ipv6-multicast-test.js
+++ b/tests/unit/validator/custom-formats/ipv6-multicast-test.js
@@ -1,0 +1,80 @@
+import {expect} from 'chai'
+import {describe, it} from 'mocha'
+import ipv6Multicast from 'bunsen-core/validator/custom-formats/ipv6-multicast'
+
+describe('validator/custom-formats/ipv6-multicast', function () {
+  it('returns false when value is undefined', function () {
+    expect(ipv6Multicast(undefined)).to.be.equal(false)
+  })
+
+  it('returns false when value is null', function () {
+    expect(ipv6Multicast(null)).to.be.equal(false)
+  })
+
+  it('returns false when value is an object', function () {
+    expect(ipv6Multicast({})).to.be.equal(false)
+  })
+
+  it('returns false when value is an array', function () {
+    expect(ipv6Multicast([])).to.be.equal(false)
+  })
+
+  it('returns false when value is an integer', function () {
+    expect(ipv6Multicast(1)).to.be.equal(false)
+  })
+
+  it('returns false when value is a float', function () {
+    expect(ipv6Multicast(0.5)).to.be.equal(false)
+  })
+
+  it('returns false when value is NaN', function () {
+    expect(ipv6Multicast(NaN)).to.be.equal(false)
+  })
+
+  it('returns false when value is Infinity', function () {
+    expect(ipv6Multicast(Infinity)).to.be.equal(false)
+  })
+
+  it('returns false when value does not consist of eight groups', function () {
+    expect(ipv6Multicast('0000/0')).to.be.equal(false)
+    expect(ipv6Multicast('0000:0000')).to.be.equal(false)
+    expect(ipv6Multicast('0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Multicast('0000:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Multicast('0000:0000:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Multicast('0000:0000:0000:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Multicast('0000:0000:0000:0000:0000:0000:0000')).to.be.equal(false)
+  })
+
+  it('returns false when groups contain non-hex characters', function () {
+    expect(ipv6Multicast('000g:0000:0000:0000:0000:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Multicast('0000:000g:0000:0000:0000:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Multicast('0000:0000:000g:0000:0000:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Multicast('0000:0000:0000:000g:0000:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Multicast('0000:0000:0000:0000:000g:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Multicast('0000:0000:0000:0000:0000:000g:0000:0000')).to.be.equal(false)
+    expect(ipv6Multicast('0000:0000:0000:0000:0000:0000:000g:0000')).to.be.equal(false)
+    expect(ipv6Multicast('0000:0000:0000:0000:0000:0000:0000:000g')).to.be.equal(false)
+  })
+
+  it('returns false when groups contain negative numbers', function () {
+    expect(ipv6Multicast('-0001:0000:0000:0000:0000:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Multicast('0000:-0001:0000:0000:0000:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Multicast('0000:0000:-0001:0000:0000:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Multicast('0000:0000:0000:-0001:0000:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Multicast('0000:0000:0000:0000:-0001:0000:0000:0000')).to.be.equal(false)
+    expect(ipv6Multicast('0000:0000:0000:0000:0000:-0001:0000:0000')).to.be.equal(false)
+    expect(ipv6Multicast('0000:0000:0000:0000:0000:0000:-0001:0000')).to.be.equal(false)
+    expect(ipv6Multicast('0000:0000:0000:0000:0000:0000:0000:-0001')).to.be.equal(false)
+  })
+
+  it('returns false when invalid IPv6 multicast', function () {
+    expect(ipv6Multicast('::1')).to.be.equal(false)
+    expect(ipv6Multicast('::')).to.be.equal(false)
+    expect(ipv6Multicast('FEDC:BA98:7654::FEDC::3210')).to.be.equal(false)
+  })
+
+  it('returns true when valid IPv6 multicast', function () {
+    expect(ipv6Multicast('FFDC:BA98:7654:3210:FEDC:BA98:7654:3210')).to.be.equal(true)
+    expect(ipv6Multicast('FF80:0:0:0:8:800:200C:417A')).to.be.equal(true)
+  })
+})

--- a/tests/unit/validator/custom-formats/ipv6-prefix-test.js
+++ b/tests/unit/validator/custom-formats/ipv6-prefix-test.js
@@ -1,0 +1,86 @@
+import {expect} from 'chai'
+import {describe, it} from 'mocha'
+import ipv6Prefix from 'bunsen-core/validator/custom-formats/ipv6-prefix'
+
+describe('validator/custom-formats/ipv6-prefix', function () {
+  it('returns false when value is undefined', function () {
+    expect(ipv6Prefix(undefined)).to.be.equal(false)
+  })
+
+  it('returns false when value is null', function () {
+    expect(ipv6Prefix(null)).to.be.equal(false)
+  })
+
+  it('returns false when value is an object', function () {
+    expect(ipv6Prefix({})).to.be.equal(false)
+  })
+
+  it('returns false when value is an array', function () {
+    expect(ipv6Prefix([])).to.be.equal(false)
+  })
+
+  it('returns false when value is an integer', function () {
+    expect(ipv6Prefix(1)).to.be.equal(false)
+  })
+
+  it('returns false when value is a float', function () {
+    expect(ipv6Prefix(0.5)).to.be.equal(false)
+  })
+
+  it('returns false when value is NaN', function () {
+    expect(ipv6Prefix(NaN)).to.be.equal(false)
+  })
+
+  it('returns false when value is Infinity', function () {
+    expect(ipv6Prefix(Infinity)).to.be.equal(false)
+  })
+
+  it('returns false when network mask is missing', function () {
+    expect(ipv6Prefix('0000:0000:0000:0000:0000:0000:0000:0000')).to.be.equal(false)
+  })
+
+  it('returns false when value does not consist of eight groups', function () {
+    expect(ipv6Prefix('0000/0')).to.be.equal(false)
+    expect(ipv6Prefix('0000:0000/0')).to.be.equal(false)
+    expect(ipv6Prefix('0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Prefix('0000:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Prefix('0000:0000:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Prefix('0000:0000:0000:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Prefix('0000:0000:0000:0000:0000:0000:0000/0')).to.be.equal(false)
+  })
+
+  it('returns false when groups contain non-hex characters', function () {
+    expect(ipv6Prefix('000g:0000:0000:0000:0000:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Prefix('0000:000g:0000:0000:0000:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Prefix('0000:0000:000g:0000:0000:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Prefix('0000:0000:0000:000g:0000:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Prefix('0000:0000:0000:0000:000g:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Prefix('0000:0000:0000:0000:0000:000g:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Prefix('0000:0000:0000:0000:0000:0000:000g:0000/0')).to.be.equal(false)
+    expect(ipv6Prefix('0000:0000:0000:0000:0000:0000:0000:000g/0')).to.be.equal(false)
+  })
+
+  it('returns false when groups contain negative numbers', function () {
+    expect(ipv6Prefix('-0001:0000:0000:0000:0000:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Prefix('0000:-0001:0000:0000:0000:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Prefix('0000:0000:-0001:0000:0000:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Prefix('0000:0000:0000:-0001:0000:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Prefix('0000:0000:0000:0000:-0001:0000:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Prefix('0000:0000:0000:0000:0000:-0001:0000:0000/0')).to.be.equal(false)
+    expect(ipv6Prefix('0000:0000:0000:0000:0000:0000:-0001:0000/0')).to.be.equal(false)
+    expect(ipv6Prefix('0000:0000:0000:0000:0000:0000:0000:-0001/0')).to.be.equal(false)
+  })
+
+  it('returns false when invalid IPv6 prefix', function () {
+    expect(ipv6Prefix('12AB:0:0:CD3/60')).to.be.equal(false)
+    expect(ipv6Prefix('12AB::CD30/60')).to.be.equal(false)
+    expect(ipv6Prefix('12AB::CD3/60')).to.be.equal(false)
+  })
+
+  it('returns true when valid IPv6 prefix', function () {
+    expect(ipv6Prefix('12AB:0000:0000:CD30:0000:0000:0000:0000/60')).to.be.equal(true)
+    expect(ipv6Prefix('12AB::CD30:0:0:0:0/60')).to.be.equal(true)
+    expect(ipv6Prefix('12AB:0:0:CD30::/60')).to.be.equal(true)
+    expect(ipv6Prefix('::/0')).to.be.equal(true)
+  })
+})

--- a/tests/unit/validator/custom-formats/utils-test.js
+++ b/tests/unit/validator/custom-formats/utils-test.js
@@ -5,10 +5,10 @@ import {hexToBinary, isMacMaskValid, isMacMulticastAddress} from 'bunsen-core/va
 describe('validator/custom-formats/utils', function () {
   describe('hexToBinary', function () {
     it('converts hexidecimal to binary properly', function () {
-      expect(hexToBinary('0xff')).to.equal('11111111')
+      expect(hexToBinary(8, '0xff')).to.equal('11111111')
     })
     it('pads the binary number with 0s', function () {
-      expect(hexToBinary('0x1')).to.equal('00000001')
+      expect(hexToBinary(8, '0x1')).to.equal('00000001')
     })
   })
 


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Added** new formats: `ipv6-interface`, `ipv6-multicast`, and `ipv6-prefix`.
