### PR TITLE
Make bunsen-core a direct dependency

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,13 @@
+{
+  "plugins": {
+    "lint": {
+      "list-item-indent": false,
+      "maximum-line-length": 119,
+      "no-duplicate-headings": false,
+      "no-multiple-toplevel-headings": false
+    }
+  },
+  "settings": {
+    "commonmark": true
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,8 @@
 
 # 0.12.0
 
-* **Added** new `forceValidation` argument to `validate` action to allow consumer to force re-validation when the value is the same.
+* **Added** new `forceValidation` argument to `validate` action to allow consumer to force re-validation when the
+value is the same.
 
 
 # 0.11.0
@@ -136,7 +137,8 @@
 
 # 0.10.0
 
-* **Upgraded** to latest `bunsen-core` to get new MAC address custom formats and `modelType` validation for select renderers.
+* **Upgraded** to latest `bunsen-core` to get new MAC address custom formats and `modelType` validation for select
+renderers.
 
 
 
@@ -341,7 +343,8 @@ Use a `# CHANGELOG` section in your Pull Request description to auto-populate th
 
 # 0.6.1
 
-* **Upgraded** to latest `bunsen-core` which fixes a bug with cells that define `children` but not `model` or `extends`.
+* **Upgraded** to latest `bunsen-core` which fixes a bug with cells that define `children` but not `model` or
+`extends`.
 
 
 
@@ -424,4 +427,3 @@ Use a `# CHANGELOG` section in your Pull Request description to auto-populate th
 # 0.0.1
 No CHANGELOG section found in Pull Request description.
 Use a `# CHANGELOG` section in your Pull Request description to auto-populate the `CHANGELOG.md`
-

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,8 +2,15 @@ The MIT License (MIT)
 
 Copyright (c) 2016
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/blueprints/ember-bunsen-core/index.js
+++ b/blueprints/ember-bunsen-core/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   afterInstall: function () {
-    return this.addPackagesToProject([
-      {name: 'bunsen-core', target: '0.22.1'}
+    return this.removePackagesFromProject([
+      {name: 'bunsen-core'}
     ])
       .then(() => {
         return this.addAddonsToProject({

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.5.0",
-    "bunsen-core": "0.22.1",
     "ember-cli": "^2.11.0",
     "ember-cli-app-version": "^2.0.1",
     "ember-cli-chai": "0.3.2",
@@ -32,7 +31,7 @@
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-htmlbars-inline-precompile": "0.3.6",
     "ember-cli-inject-live-reload": "^1.6.1",
-    "ember-cli-mocha": "0.13.1",
+    "ember-cli-mocha": "0.13.2",
     "ember-cli-moment-shim": "^3.0.1",
     "ember-cli-test-loader": "^1.1.1",
     "ember-cli-uglify": "^1.2.0",
@@ -60,6 +59,7 @@
   ],
   "dependencies": {
     "broccoli-merge-trees": "^1.0.0",
+    "bunsen-core": "0.22.1",
     "ember-cli-babel": "^5.1.6"
   },
   "ember-addon": {


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG

* **Changed** `bunsen-core` from a blueprint installation to a direct dependency so consumers don't have to manage it's version on top of this addon.
