### PR TITLE
Bump core version to fix view/model normalization errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   ],
   "dependencies": {
     "broccoli-merge-trees": "^1.0.0",
-    "bunsen-core": "0.30.9",
+    "bunsen-core": "0.30.10",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-moment-shim": "^2.0.0",
     "ember-lodash-shim": "^2.0.0",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
Incorrect views no longer cause normalization to crash. Instead, model and view are returned unchanged.