### PR TITLE
Update ember-cli-moment-shim to 3.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "broccoli-merge-trees": "^2.0.0",
     "bunsen-core": "^2.0.7",
     "ember-cli-babel": "^5.1.7",
-    "ember-cli-moment-shim": "^3.0.1",
+    "ember-cli-moment-shim": "3.3.3",
     "ember-lodash-shim": "^2.0.7",
     "ember-seamless-immutable-shim": "^3.0.0",
     "ember-validator-shim": "^3.0.0",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [X] #major# - incompatible API change

Closes: https://agile-jira.ciena.com/browse/FROST-1236

# CHANGELOG
* **Updated** `ember-cli-moment-shim` to `3.3.3`